### PR TITLE
Improve pypy compatability

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -27,6 +27,10 @@ except ImportError:
     # print("Warning: numpy not available... functionality will be limited.")
     pass
 
+builtins = __builtins__
+if not isinstance(builtins, dict):
+    builtins = builtins.__dict__
+    
 class Interpreter:
     """mathematical expression compiler and interpreter.
 
@@ -86,8 +90,8 @@ class Interpreter:
 
         symtable['print'] = self._printer
         for sym in FROM_PY:
-            if sym in __builtins__:
-                symtable[sym] = __builtins__[sym]
+            if sym in builtins:
+                symtable[sym] = builtins[sym]
 
         for symname, obj in LOCALFUNCS.items():
             symtable[symname] = obj
@@ -565,7 +569,7 @@ class Interpreter:
                 for hnd in node.handlers:
                     htype = None
                     if hnd.type is not None:
-                        htype = __builtins__.get(hnd.type.id, None)
+                        htype = builtins.get(hnd.type.id, None)
                     if htype is None or isinstance(e_type(), htype):
                         self.error = []
                         if hnd.name is not None:


### PR DESCRIPTION
`__builtins__` behaves slightly different on pypy vs CPython:
- on CPython: the docs say "The value of `__builtins__` is normally either this module or the value of this module’s `__dict__` attribute". This is affected by whether this is the `__main__` module.
- on pypy: this is always the module.

When it's the module, the dict lives inside of the __dict__ attribute

I've tested this by running the unittests on Python 2 + Python 3.
Tests don't pass yet on PyPy (due to NumPy being missing), but the non-numpy ones do pass