### PR TITLE
__all__ should list strings of names, not objects

### DIFF
--- a/asteval/__init__.py
+++ b/asteval/__init__.py
@@ -23,4 +23,4 @@ from .asteval import Interpreter
 from .astutils import NameFinder, valid_symbol_name
 
 __version__ = '0.9.7'
-__all__ = [Interpreter, NameFinder, valid_symbol_name]
+__all__ = ['Interpreter', 'NameFinder', 'valid_symbol_name']


### PR DESCRIPTION
See e.g. [`__all__` in the stdlib subprocess module](https://hg.python.org/cpython/file/3.5/Lib/subprocess.py#l459).

Originally reported as ipython/ipython#9678.