### PR TITLE
Add check for 'try' before assigning it

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -122,8 +122,9 @@ class Interpreter:
                                    for node in self.supported_nodes))
 
         # to rationalize try/except try/finally for Python2.6 through Python3.3
-        self.node_handlers['tryexcept'] = self.node_handlers['try']
-        self.node_handlers['tryfinally'] = self.node_handlers['try']
+        if 'try' in self.node_handlers:
+            self.node_handlers['tryexcept'] = self.node_handlers['try']
+            self.node_handlers['tryfinally'] = self.node_handlers['try']
 
         self.no_deepcopy = []
         for key, val in symtable.items():


### PR DESCRIPTION
Hi,
This is a really nice project. Thank you :)

This is something I faced when I wanted support a smaller subset of `supported_nodes` (as mentioned in Issue #13 ). 

```
In [1]: from asteval.asteval import Interpreter

In [2]: reqd_entries = ['binop','boolop','compare','expr','module','name','num','str','nameconstant','unaryop']

In [3]: Interpreter.supported_nodes = tuple(reqd_entries)

In [4]: asteval = Interpreter()
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-4-92399253e0b7> in <module>()
----> 1 asteval = Interpreter()

/Users/nithin/myspace/asteval/asteval/asteval.py in __init__(self, symtable, writer, use_numpy, err_writer, max_time)
    123
    124         # to rationalize try/except try/finally for Python2.6 through Python3.3
--> 125         self.node_handlers['tryexcept'] = self.node_handlers['try']
    126         self.node_handlers['tryfinally'] = self.node_handlers['try']
    127

KeyError: 'try'
```
To overcome this, `try` needs to be included in `supported_nodes`, even if I do not want it.
This pull request just checks if the 'try' key is present before assigning them.

