### PR TITLE
Safer procedures

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -776,7 +776,6 @@ class Procedure(object):
             msg = "%s() takes at least %i arguments, got %i"
             self.raise_exc(None, exc=TypeError,
                            msg=msg % (self.name, nargs_expected, nargs))
-            return
         # check for multiple values for named argument
         if len(self.argnames) > 0 and kwargs is not None:
             msg = "%s() got multiple values for keyword argument '%s'"
@@ -784,7 +783,6 @@ class Procedure(object):
                 if targ in kwargs:
                     self.raise_exc(None, exc=TypeError,
                                    msg=msg % (targ, self.name))
-                    return
 
         # check more args given than expected, varargs not given
         if nargs > nargs_expected and self.vararg is None:
@@ -792,7 +790,7 @@ class Procedure(object):
                 msg = 'too many arguments for %s() expected at most %i, got %i'
                 msg = msg % (self.name, len(self.kwargs)+nargs_expected, nargs)
                 self.raise_exc(None, exc=TypeError, msg=msg)
-                return
+
             for i, xarg in enumerate(args[nargs_expected:]):
                 kw_name = self.kwargs[i][0]
                 if kw_name not in kwargs:

--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -294,12 +294,3 @@ class NameFinder(ast.NodeVisitor):
             if node.ctx.__class__ == ast.Load and node.id not in self.names:
                 self.names.append(node.id)
         ast.NodeVisitor.generic_visit(self, node)
-
-
-def get_ast_names(astnode):
-    """returns symbol Names from an AST node
-    :param astnode:
-    """
-    finder = NameFinder()
-    finder.generic_visit(astnode)
-    return finder.names

--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -30,7 +30,7 @@ UNSAFE_ATTRS = ('__subclasses__', '__bases__', '__globals__', '__code__',
                 '__getattribute__', '__subclasshook__', '__new__',
                 '__init__', 'func_globals', 'func_code', 'func_closure',
                 'im_class', 'im_func', 'im_self', 'gi_code', 'gi_frame',
-                '__asteval__', 'f_locals')
+                '__asteval__', 'f_locals', '__mro__')
 
 # inherit these from python's __builtins__
 FROM_PY = ('ArithmeticError', 'AssertionError', 'AttributeError',
@@ -52,7 +52,7 @@ FROM_PY = ('ArithmeticError', 'AssertionError', 'AttributeError',
            'hash', 'hex', 'id', 'int', 'isinstance', 'len', 'list', 'map',
            'max', 'min', 'oct', 'ord', 'pow', 'range', 'repr',
            'reversed', 'round', 'set', 'slice', 'sorted', 'str', 'sum',
-           'tuple', 'type', 'zip')
+           'tuple', 'zip')
 
 # inherit these from python's math
 FROM_MATH = ('acos', 'acosh', 'asin', 'asinh', 'atan', 'atan2', 'atanh',
@@ -151,8 +151,11 @@ def _open(filename, mode='r', buffering=0):
         raise RuntimeError("Invalid buffering value, max buffer size is {}".format(MAX_OPEN_BUFFER))
     return open(filename, mode, buffering)
 
+def _type(obj, *varargs, **varkws):
+    """type that prevents varargs and varkws"""
+    return type(obj)
 
-LOCALFUNCS = {'open': _open}
+LOCALFUNCS = {'open': _open, 'type', _type}
 
 
 # Safe versions of functions to prevent denial of service issues

--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -155,7 +155,7 @@ def _type(obj, *varargs, **varkws):
     """type that prevents varargs and varkws"""
     return type(obj)
 
-LOCALFUNCS = {'open': _open, 'type', _type}
+LOCALFUNCS = {'open': _open, 'type': _type}
 
 
 # Safe versions of functions to prevent denial of service issues

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -470,7 +470,8 @@ class TestEval(TestCase):
                               ('x = astr * atup', 'TypeError'),
                               ('x = arr.shapx', 'AttributeError'),
                               ('arr.shapx = 4', 'AttributeError'),
-                              ('del arr.shapx', 'KeyError')):
+                              ('del arr.shapx', 'KeyError'),
+                              ('x, y = atup', 'ValueError')):
             failed, errtype, errmsg = False, None, None
             # noinspection PyBroadException
             try:
@@ -698,7 +699,7 @@ class TestEval(TestCase):
     def test_function_kwargs(self):
         """test function with kw args, no **kws"""
         self.interp(textwrap.dedent("""
-            def fcn(square=False, x=0, y=0, z=0, t=0):
+            def fcn(x=0, y=0, z=0, t=0, square=False):
                 'test varargs function'
                 out = 0
                 for i in (x, y, z, t):
@@ -714,10 +715,22 @@ class TestEval(TestCase):
         self.isvalue('o', 6)
         self.interp("o = fcn(x=1, y=2, z=3, square=True)")
         self.isvalue('o', 14)
+        self.interp("o = fcn(3, 4, 5)")
+        self.isvalue('o', 12)
+        self.interp("o = fcn(0, -1, 1)")
+        self.isvalue('o', 0)
+        self.interp("o = fcn(0, -1, 1, square=True)")
+        self.isvalue('o', 2)
+        self.interp("o = fcn(1, -1, 1, 1, True)")
+        self.isvalue('o', 4)
         self.interp("o = fcn(x=1, y=2, z=3, t=-2)")
         self.isvalue('o', 4)
         self.interp("o = fcn(x=1, y=2, z=3, t=-12, s=1)")
         self.check_error('TypeError', 'extra keyword arg')
+        self.interp("o = fcn(x=1, y=2, y=3)")
+        self.check_error('SyntaxError')
+        self.interp("o = fcn(0, 1, 2, 3, 4, 5, 6, 7, True)")
+        self.check_error('TypeError', 'too many arguments')
 
     def test_function_kwargs1(self):
         """test function with **kws arg"""


### PR DESCRIPTION
This attempts to address #32.  It may not be complete, but I think it addresses the most important point of that error -- that Procedure properties, including `body` can be overwritten.