### PR TITLE
Include called function's exception message on failed on_call

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -756,8 +756,10 @@ class Interpreter(object):
 
         try:
             return func(*args, **keywords)
-        except:
-            self.raise_exception(node, msg="Error running %s" % (func))
+        except Exception as ex:
+            self.raise_exception(
+                node, msg="Error running function call '%s': %s"
+                % (func.__name__, ex))
 
     def on_arg(self, node):    # ('test', 'msg')
         """Arg for function definitions."""


### PR DESCRIPTION
Currently any user-defined methods that raise an exception inside of the interpreter are re-raised by the `raise_exception` function without the message from the original exception. See below for example:

```
In [1]: import asteval

In [2]: def foo():
   ...:     raise Exception("Example error")
   ...:

In [3]: interpreter = asteval.Interpreter(usersyms={"foo": foo})

In [4]: interpreter("foo()")
Exception
   foo()
Error running <function foo at 0x07D9E030>
```

Having the original exception message is important for debugging, so I've added the original error message to the call to `raise_exception`. In addition, I think having the function name is more useful than having the whole function, so I also changed that. Now an error message will look like this:

```
In [1]: import asteval

In [2]: def foo():
   ...:     raise Exception("Example error")
   ...:

In [3]: interpreter = asteval.Interpreter(usersyms={"foo": foo})

In [4]: interpreter("foo()")
Exception
   foo()
Error running function call 'foo': Example error
```

I tested/developed this in Python 3.6. In addition, I ran all of the unittests that are included in this repository.