### PR TITLE
Give Procedure objects a __name__ attribute

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -758,8 +758,8 @@ class Interpreter(object):
             return func(*args, **keywords)
         except Exception as ex:
             self.raise_exception(
-                node, msg="Error running function call '%s': %s"
-                % (func.__name__, ex))
+                node, msg="Error running function call '%s' with args %s and "
+                "kwargs %s: %s" % (func.__name__, args, keywords, ex))
 
     def on_arg(self, node):    # ('test', 'msg')
         """Arg for function definitions."""
@@ -819,6 +819,7 @@ class Procedure(object):
         """TODO: docstring in public method."""
         self.__ininit__ = True
         self.name = name
+        self.__name__ = self.name
         self.__asteval__ = interp
         self.raise_exc = self.__asteval__.raise_exception
         self.__doc__ = doc


### PR DESCRIPTION
The error discussed in #42 was due to the `on_call` function calling either a function or a `Procedure` object. While functions have a `__name__` attribute, `Procedure` objects did not, which caused a `AttributeError` to be raised whenever an exception occurred in the evaluated line (see [this](https://travis-ci.org/newville/asteval/builds/416559346?utm_source=github_status&utm_medium=notification) test failure).

I've remedied this by giving `Procedure` objects a `__name__` attribute. I'll acknowledge that this is a bit redundant since they already have a `name` attribute, so we have several options on how we'd want to proceed:

* Leave it the way it is
* Convert all `Procedure.name` references to `Procedure.__name__`
* Add logic into the exception handler in `on_call` to differentiate between `Procedure`s and functions, then call either `name` or `__name__` respectively
* Go back to the way it used to be, don't reference the function's name in the error message

Here's an example demonstrating that the correct error occurs:

```
In [7]: i("""def foo(): return foo()\nfoo()""")
RecursionError
   <>
                      ^^^
Error running function call 'foo' with args [] and kwargs {}: maximum recursion
depth exceeded while calling a Python object

In [8]: def bar(): raise Exception("example")

In [9]: i.symtable['bar'] = bar

In [10]: i("bar()")
Exception
   bar()
Error running function call 'bar' with args [] and kwargs {}: example
```