### PR TITLE
Added options symblacklist and blacklist_builtins

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -110,7 +110,7 @@ class Interpreter(object):
         deprecated.  max run time in seconds (see Note 2) [30.0]
     symblacklist : iterable or `None`
         symbols that the user can not assign to
-    blacklist_buildins : bool
+    blacklist_builtins : bool
         whether to blacklist all symbols that are in the initial symtable
 
     Notes
@@ -126,7 +126,7 @@ class Interpreter(object):
                  no_functiondef=False, no_ifexp=False, no_listcomp=False,
                  no_augassign=False, no_assert=False, no_delete=False,
                  no_raise=False, no_print=False, max_time=30,
-                 symblacklist=None, blacklist_buildins=False):
+                 symblacklist=None, blacklist_builtins=False):
 
         self.writer = writer or stdout
         self.err_writer = err_writer or stderr
@@ -190,7 +190,7 @@ class Interpreter(object):
         else:
             self.symblacklist = set(symblacklist)
 
-        if blacklist_buildins:
+        if blacklist_builtins:
             self.symblacklist |= set(self.symtable)
 
         self.no_deepcopy = [key for key, val in symtable.items()

--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -566,7 +566,7 @@ class Interpreter(object):
                 children.append(tnode.attr)
                 tnode = tnode.value
 
-            if tnode.__class__ == ast.Name:
+            if tnode.__class__ == ast.Name and tnode.id not in self.symblacklist:
                 children.append(tnode.id)
                 children.reverse()
                 self.symtable.pop('.'.join(children))

--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -784,6 +784,10 @@ class Interpreter(object):
         if node.decorator_list:
             raise Warning("decorated procedures not supported!")
         kwargs = []
+        
+        if not valid_symbol_name(node.name) or node.name in self.readonly_symbols:
+            errmsg = "invalid function name (reserved word?) %s" % node.name
+            self.raise_exception(node, exc=NameError, msg=errmsg)
 
         offset = len(node.args.args) - len(node.args.defaults)
         for idef, defnode in enumerate(node.args.defaults):

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -910,6 +910,60 @@ class TestEval(TestCase):
         assert_allclose(x1, 0.50,     rtol=0.001)
         assert_allclose(x2, 0.866025, rtol=0.001)
         assert_allclose(x3, 1.00,     rtol=0.001)
+    
+    def test_readonly_symbols(self):
+        
+        def foo():
+            return 31
+        
+        
+        usersyms = {
+            "a": 10,
+            "b": 11,
+            "c": 12,
+            "d": 13,
+            "foo": foo,
+            "bar": foo,
+            "x": 5,
+            "y": 7
+        }
+        
+        aeval = Interpreter(usersyms=usersyms, readonly_symbols={"a", "b", "c", "d", "foo", "bar"})
+        
+        aeval("a = 20")
+        aeval("def b(): return 100")
+        aeval("c += 1")
+        aeval("del d")
+        aeval("def foo(): return 55")
+        aeval("bar = None")
+        aeval("x = 21")
+        aeval("y += a")
+        
+        assert(aeval("a") == 10)
+        assert(aeval("b") == 11)
+        assert(aeval("c") == 12)
+        assert(aeval("d") == 13)
+        assert(aeval("foo()") == 31)
+        assert(aeval("bar()") == 31)
+        assert(aeval("x") == 21)
+        assert(aeval("y") == 17)
+        
+        
+        assert(aeval("abs(8)") == 8)
+        assert(aeval("abs(-8)") == 8)
+        aeval("def abs(x): return x*2")
+        assert(aeval("abs(8)") == 16)
+        assert(aeval("abs(-8)") == -16)
+        
+        aeval2 = Interpreter(builtins_readonly=True)
+        
+        assert(aeval2("abs(8)") == 8)
+        assert(aeval2("abs(-8)") == 8)
+        aeval2("def abs(x): return x*2")
+        assert(aeval2("abs(8)") == 8)
+        assert(aeval2("abs(-8)") == 8)
+        
+        
 
 
 


### PR DESCRIPTION
The symblacklist is a set of names that can not be assigned to (count as reserved)
blacklist_builtins will, if set, put all names in the initial symtable in the symblacklist, thereby disallowing users to overwrite those.

This will be especially useful if the same Interpreter is used by multiple users:
With this the users can use each others functions, but they will not be able to break the builtin functions.
'buildin' here means any name that is in the initial symtable

I have not yet ran the tests or created tests for these options because of issue #44 
When testing manually it seemed to work.