### PR TITLE
Don't raise self.error_msg. Instead let error message bubble up through exceptions

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -245,7 +245,7 @@ class Interpreter(object):
                 exc = self.error[0].exc
             except:
                 exc = RuntimeError
-        raise exc(self.error_msg)
+        raise exc(msg)
 
     # main entry point for Ast node evaluation
     #  parse:  text of statements -> ast
@@ -295,9 +295,9 @@ class Interpreter(object):
             if isinstance(ret, enumerate):
                 ret = list(ret)
             return ret
-        except:
+        except Exception as ex:
             if with_raise:
-                self.raise_exception(node, expr=expr)
+                self.raise_exception(node, msg=str(ex), expr=expr)
 
     def __call__(self, expr, **kw):
         """Call class instance as function."""
@@ -324,10 +324,12 @@ class Interpreter(object):
             return
         try:
             return self.run(node, expr=expr, lineno=lineno)
-        except:
-            errmsg = exc_info()[1]
-            if len(self.error) > 0:
-                errmsg = "\n".join(self.error[0].get_error())
+        except Exception as ex:
+            errmsg = str(ex)
+            if len(errmsg) < 1:
+                errmsg = exc_info()[1]
+                if len(self.error) > 0:
+                    errmsg = "\n".join(self.error[0].get_error())
             if not show_errors:
                 try:
                     exc = self.error[0].exc
@@ -759,7 +761,7 @@ class Interpreter(object):
         except Exception as ex:
             self.raise_exception(
                 node, msg="Error running function call '%s' with args %s and "
-                "kwargs %s: %s" % (func.__name__, args, keywords, ex))
+                "kwargs %s:\n%s" % (func.__name__, args, keywords, ex))
 
     def on_arg(self, node):    # ('test', 'msg')
         """Arg for function definitions."""


### PR DESCRIPTION
This will fix #44 

Because `self.error_msg` is included not included in the raised message anymore, its size will not grow exponentially anymore but only quadratically.
`self.error_msg` isn't really used anywhere anymore and could also be removed completely

Printing the actual error message that is caught in eval also seemed more logical than manually trying to inspect the errors for some printable message.

The printed error message for a recursion error (with the repetitions in the middle left out) is now:

    >>> import asteval; aeval=asteval.Interpreter()
    >>> aeval("def foo(): foo()\nfoo()")           
    Error running function call 'foo' with args [] and kwargs {}:
    Error running function call 'foo' with args [] and kwargs {}:
    (...)
    Error running function call 'foo' with args [] and kwargs {}:
    Error running function call 'foo' with args [] and kwargs {}:
    maximum recursion depth exceeded while calling a Python object