### PR TITLE
Proposal: completely overhaul exception handling

### DIFF
--- a/asteval/__init__.py
+++ b/asteval/__init__.py
@@ -21,7 +21,7 @@ from .asteval import Interpreter
 from .astutils import (NameFinder, valid_symbol_name,
                        make_symbol_table, get_ast_names)
 from .exceptions import (EvalError, TimeOutError, UserError,
-                         RaisedError, BuiltinError)
+                         RaisedError, BuiltinError, OperatorError)
 from ._version import get_versions
 
 __all__ = ['Interpreter', 'NameFinder', 'valid_symbol_name',

--- a/asteval/__init__.py
+++ b/asteval/__init__.py
@@ -20,6 +20,8 @@
 from .asteval import Interpreter
 from .astutils import (NameFinder, valid_symbol_name,
                        make_symbol_table, get_ast_names)
+from .exceptions import (EvalError, TimeOutError, UserError,
+                         RaisedError, BuiltinError)
 from ._version import get_versions
 
 __all__ = ['Interpreter', 'NameFinder', 'valid_symbol_name',

--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -749,7 +749,7 @@ class Interpreter(object):
         
         if not valid_symbol_name(node.name) or node.name in self.readonly_symbols:
             errmsg = "invalid function name (reserved word?) %s" % node.name
-            self.raise_exception(node, exc=NameError, msg=errmsg)
+            raise UserError(NameError(errmsg))
 
         offset = len(node.args.args) - len(node.args.defaults)
         for idef, defnode in enumerate(node.args.defaults):

--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -578,12 +578,7 @@ class Interpreter(object):
         is_and = ast.And == node.op.__class__
         if (is_and and val) or (not is_and and not val):
             for n in node.values[1:]:
-                op = self.run(n)
-                func = op2func(node.op)
-                try:
-                    val = func(val, op)
-                except Exception as err:
-                    self.raise_exception(OperatorError, err, node)
+                val = op2func(node.op)(val, self.run(n))
                 if (is_and and not val) or (not is_and and val):
                     break
         return val

--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -48,7 +48,7 @@ import six
 
 from .astutils import (UNSAFE_ATTRS, HAS_NUMPY, make_symbol_table, numpy,
                        op2func, ExceptionHolder, ReturnedNone,
-                       valid_symbol_name)
+                       valid_symbol_name, is_recursion_error)
 from .exceptions import (EvalError, TimeOutError, UserError,
                          RaisedError, BuiltinError)
 from .scope import Scope
@@ -758,6 +758,11 @@ class Interpreter(object):
             else:
                 line = ""
             raise eex.extend_traceback("File \"%s\", line %d, in %s%s" % (self.filename, lineno, self.scope.name, line))
+        except RuntimeError as rex:
+            if is_recursion_error(rex):
+                self.raise_exception(UserError, rex, node)
+            else:
+                raise
         except Exception as ex:
             if not isinstance(func, Procedure):
                 self.raise_exception(BuiltinError, ex, node)

--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -745,7 +745,7 @@ class Interpreter(object):
         try:
             return func(*args, **keywords)
         except Exception as ex:
-            if isinstance(func, Procedure):
+            if not isinstance(func, Procedure):
                 raise BuiltinError(ex)
             #self.raise_exception(
                 #node, msg="Error running function call '%s' with args %s and "

--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -47,7 +47,7 @@ from sys import exc_info, stdout, stderr, version_info
 import six
 
 from .astutils import (UNSAFE_ATTRS, HAS_NUMPY, make_symbol_table, numpy,
-                       op2func, ExceptionHolder, ReturnedNone,
+                       op2func, ReturnedNone,
                        valid_symbol_name, is_recursion_error, is_exception)
 from .exceptions import (EvalError, TimeOutError, UserError,
                          RaisedError, BuiltinError, OperatorError)
@@ -81,7 +81,7 @@ class Interpreter(object):
     writer : file-like or `None`
         callable file-like object where standard output will be sent.
     err_writer : file-like or `None`
-        callable file-like object where standard error will be sent.
+        deprecated. Errors will now be raised instead of written to a stream
     use_numpy : bool
         whether to use functions from numpy.
     minimal : bool
@@ -133,7 +133,6 @@ class Interpreter(object):
                  readonly_symbols=None, builtins_readonly=False):
 
         self.writer = writer or stdout
-        self.err_writer = err_writer or stderr
 
         if symtable is None:
             if usersyms is None:

--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -722,17 +722,21 @@ class Interpreter(object):
             msgnode = node.inst
         if excnode is None:
             ex = exc_info()
-            if ex is None:
+            if ex is None or ex[1] is None:
                 if version_info[0] == 3:
                     exception = RuntimeError("No active exception to raise")
                 else:
                     exception = None # will fail type check later
-            extype, exception, strace = ex
+            else:
+                extype, exception, strace = ex
         else:
             exception = self.run(excnode)
         
         if not is_exception(exception):
             self.raise_exception(UserError, TypeError("exceptions must derive from BaseException"), node)
+        
+        if isinstance(exception, type):
+            exception = exception()
         
         if msgnode is not None:
             cause = self.run(msgnode)
@@ -744,6 +748,8 @@ class Interpreter(object):
         else:
             if not is_exception(cause):
                 self.raise_exception(UserError, TypeError("exception causes must derive from BaseException"))
+            if isinstance(cause, type):
+                cause = cause()
             self.raise_exception(RaisedError, exception, node, cause)
         
 

--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -648,9 +648,11 @@ class Interpreter(object):
             for tnode in node.body:
                 self.run(tnode)
         except UserError as uerr:
-            err = UserError.get_error()
+            err = uerr.get_error()
             for handler in node.handlers:
-                htype = self.symtable.get(handler.type)
+                htype = self.run(handler.type)
+                if not (isinstance(htype, BaseException) or issubclass(htype, BaseException)):
+                    raise UserError(TypeError("catching classes that do not inherit from BaseException is not allowed"))
                 if handler.type is None or isinstance(err, htype):
                     if handler.name is not None:
                         self.node_assign(handler.name, err)

--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -949,8 +949,6 @@ class Procedure(object):
             # evaluate script of function
             for node in self.body:
                 self.__asteval__.run(node)
-                if len(self.__asteval__.error) > 0:
-                    break
                 if self.__asteval__.retval is not None:
                     retval = self.__asteval__.retval
                     self.__asteval__.retval = None
@@ -959,7 +957,6 @@ class Procedure(object):
                     break
         finally:
             self.__asteval__.scope = current_scope
-        return out
 
         self.__asteval__.symtable = save_symtable
         symlocals = None

--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -506,6 +506,8 @@ class Interpreter(object):
     def on_subscript(self, node):    # ('value', 'slice', 'ctx')
         """Subscript handling -- one of the tricky parts."""
         val = self.run(node.value)
+        if not hasattr(val, "__getitem__"):
+            self.raise_exception(UserError, TypeError("'%s' object is not subscriptable" % val.__class__.__name__), node)
         nslice = self.run(node.slice)
         ctx = node.ctx.__class__
         if ctx in (ast.Load, ast.Store):

--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -8,6 +8,7 @@ from __future__ import division, print_function
 import re
 import ast
 import math
+import sys
 from sys import exc_info
 
 HAS_NUMPY = False
@@ -374,3 +375,12 @@ def make_symbol_table(use_numpy=True, **kws):
     symtable.update(kws)
 
     return symtable
+
+def is_recursion_error(error):
+    if sys.version_info >= (3, 5):
+        if isinstance(error, RecursionError):
+            return True
+    else:
+        if str(error) == "maximum recursion depth exceeded":
+            return True
+    return False

--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -381,6 +381,6 @@ def is_recursion_error(error):
         if isinstance(error, RecursionError):
             return True
     else:
-        if isinstance(error, RuntimeError) and str(error) == "maximum recursion depth exceeded":
+        if isinstance(error, RuntimeError) and "maximum recursion depth exceeded" in str(error):
             return True
     return False

--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -381,6 +381,6 @@ def is_recursion_error(error):
         if isinstance(error, RecursionError):
             return True
     else:
-        if str(error) == "maximum recursion depth exceeded":
+        if isinstance(error, RuntimeError) and str(error) == "maximum recursion depth exceeded":
             return True
     return False

--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -272,44 +272,6 @@ class Empty:
 ReturnedNone = Empty()
 
 
-class ExceptionHolder(object):
-    """Basic exception handler."""
-
-    def __init__(self, node, exc=None, msg='', expr=None, lineno=None):
-        """TODO: docstring in public method."""
-        self.node = node
-        self.expr = expr
-        self.msg = msg
-        self.exc = exc
-        self.lineno = lineno
-        self.exc_info = exc_info()
-        if self.exc is None and self.exc_info[0] is not None:
-            self.exc = self.exc_info[0]
-        if self.msg is '' and self.exc_info[1] is not None:
-            self.msg = self.exc_info[1]
-
-    def get_error(self):
-        """Retrieve error data."""
-        col_offset = -1
-        if self.node is not None:
-            try:
-                col_offset = self.node.col_offset
-            except AttributeError:
-                pass
-        try:
-            exc_name = self.exc.__name__
-        except AttributeError:
-            exc_name = str(self.exc)
-        if exc_name in (None, 'None'):
-            exc_name = 'UnknownError'
-
-        out = ["   %s" % self.expr]
-        if col_offset > 0:
-            out.append("    %s^^^" % ((col_offset)*' '))
-        out.append(str(self.msg))
-        return (exc_name, '\n'.join(out))
-
-
 class NameFinder(ast.NodeVisitor):
     """Find all symbol names used by a parsed node."""
 

--- a/asteval/exceptions.py
+++ b/asteval/exceptions.py
@@ -5,7 +5,7 @@ class EvalError(Exception):
 
 class UserError(EvalError):
     
-    def get_error():
+    def get_error(self):
         if len(self.args):
             return self.args[0]
         else:

--- a/asteval/exceptions.py
+++ b/asteval/exceptions.py
@@ -1,0 +1,21 @@
+
+
+class EvalError(Exception):
+    pass
+
+class UserError(EvalError):
+    
+    def get_error():
+        if len(self.args):
+            return self.args[0]
+        else:
+            return None
+
+class RaisedError(UserError):
+    pass
+
+class BuiltinError(UserError):
+    pass
+
+class TimeOutError(EvalError):
+    pass

--- a/asteval/exceptions.py
+++ b/asteval/exceptions.py
@@ -20,5 +20,8 @@ class RaisedError(UserError):
 class BuiltinError(UserError):
     pass
 
+class OperatorError(BuiltinError):
+    pass
+
 class TimeOutError(EvalError):
     pass

--- a/asteval/exceptions.py
+++ b/asteval/exceptions.py
@@ -1,15 +1,18 @@
 
 
 class EvalError(Exception):
-    pass
+    def __init__(self, error=None, traceback="", cause=None, *args):
+        self.error = error
+        self.traceback = traceback
+        self.cause = cause
+        self.args = [self.error, self.traceback, self.cause, *args]
+    
+    def extend_traceback(self, tb_msg):
+        return self.__class__(self.error, tb_msg + '\n' + self.traceback, *self.args[2:])
+        
 
 class UserError(EvalError):
-    
-    def get_error(self):
-        if len(self.args):
-            return self.args[0]
-        else:
-            return None
+    pass
 
 class RaisedError(UserError):
     pass

--- a/asteval/exceptions.py
+++ b/asteval/exceptions.py
@@ -5,7 +5,7 @@ class EvalError(Exception):
         self.error = error
         self.traceback = traceback
         self.cause = cause
-        self.args = [self.error, self.traceback, self.cause, *args]
+        self.args = (self.error, self.traceback, self.cause) + args
     
     def extend_traceback(self, tb_msg):
         return self.__class__(self.error, tb_msg + '\n' + self.traceback, *self.args[2:])

--- a/asteval/scope.py
+++ b/asteval/scope.py
@@ -1,0 +1,6 @@
+
+class Scope:
+    
+    def __init__(self, name, parent):
+        self.name = name
+        self.parent = parent

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -1003,6 +1003,14 @@ class TestEval(TestCase):
         with raises(asteval.UserError) as errinf:
             aeval("bar = None")
         self.check_user_error(errinf, NameError)
+        with raises(asteval.UserError) as errinf:
+            aeval(textwrap.dedent("""
+                try:
+                    raise Exception
+                except Exception as a:
+                    pass
+                """))
+        self.check_user_error(errinf, NameError)
         aeval("x = 21")
         aeval("y += a")
 

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -575,6 +575,21 @@ class TestEval(TestCase):
         with raises(asteval.RaisedError) as errinf:
             self.interp("raise NameError('bob')")
         self.check_user_error(errinf, NameError, 'bob')
+        
+        with raises(asteval.UserError) as errinf:
+            self.interp("raise 'error'")
+        self.check_user_error(errinf, TypeError, "from BaseException")
+        
+        with raises(asteval.UserError) as errinf:
+            self.interp("raise")
+        if PY3:
+            self.check_user_error(errinf, RuntimeError, "No active exception to raise")
+        else:
+            self.check_user_error(errinf, TypeError, "from BaseException")
+        
+        with raises(asteval.RaisedError) as errinf:
+            self.interp("raise IndexError")
+        self.check_user_error(errinf, IndexError)
 
     def test_tryexcept(self):
         """test try/except"""

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -642,6 +642,32 @@ class TestEval(TestCase):
         assert type(err) == IndexError
         assert str(err) == ""
         
+        with raises(asteval.RaisedError) as errinf:
+            self.interp(textwrap.dedent("""
+                try:
+                    raise IndexError()
+                except IndexError:
+                    raise
+                """))
+        self.check_user_error(errinf, IndexError)
+        
+        with raises(asteval.RaisedError) as errinf:
+            self.interp(textwrap.dedent("""
+                try:
+                    raise IndexError()
+                except IndexError:
+                    raise AttributeError()
+                """))
+        self.check_user_error(errinf, AttributeError)
+        
+        with raises(asteval.RaisedError) as errinf:
+            self.interp(textwrap.dedent("""
+                try:
+                    raise NameError()
+                except RuntimeError:
+                    pass
+                """))
+        self.check_user_error(errinf, NameError)
         
 
     def test_tryelsefinally(self):
@@ -669,6 +695,20 @@ class TestEval(TestCase):
         self.isvalue("val", -1)
         self.isvalue("ok", False)
         self.isvalue("clean", True)
+        
+        with raises(asteval.RaisedError) as errinf:
+            self.interp(textwrap.dedent("""
+                x = 1
+                try:
+                    raise IndexError()
+                except IndexError:
+                    x = x + 10
+                    raise AttributeError()
+                finally:
+                    x = x * 2
+                """))
+        self.check_user_error(errinf, AttributeError)
+        self.isvalue("x", 22)
 
     def test_function1(self):
         """test function definition and running"""

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -622,6 +622,28 @@ class TestEval(TestCase):
             """))
         self.isvalue('x', 15)
 
+        self.interp(textwrap.dedent("""
+            try:
+                raise RuntimeError("hello")
+            except Exception as ex:
+                err = ex
+            """))
+        err = self.interp.symtable.get("err")
+        assert type(err) == RuntimeError
+        assert str(err) == "hello"
+        
+        self.interp(textwrap.dedent("""
+            try:
+                raise IndexError
+            except IndexError as ex:
+                err = ex
+            """))
+        err = self.interp.symtable.get("err")
+        assert type(err) == IndexError
+        assert str(err) == ""
+        
+        
+
     def test_tryelsefinally(self):
 
         self.interp(textwrap.dedent("""


### PR DESCRIPTION
The current code uses a manual exception stack to keep track of what exceptions are raised in the code.
All exceptions are eventually caught and only logged in `err_writer`.
Maybe I don't understand properly how this error handling works, but it looks quite messy to me.

With this change the normal python exception structure is used in the interpreter.

Here asteval does not try to catch and log all errors, but instead to wrap and re-raise them.

All errors that are raised as a result of the code being evaluated are derived from `asteval.EvalError`.
All errors that can be caught from within the evaluated code are derived from `asteval.UserError`.
`asteval.UserError`s are only wrappers around the actual error.

`SyntaxError`s are not being wrapped because the parsing is a separate thing.

If you want to implement a simple REPL it could look like this:

    aeval = asteval.Interpreter()
    while True:
        try:
            inp = input() # assuming python 3
            print(self.aeval(inp))
        except SyntaxError as e:
            error = e
        except asteval.UserError as e:
            error = e.get_error()
        except asteval.EvalError as e:
            error = e
        if error is not None:
            print(str(error.__class__.__name__) + ":", str(error))

What do you think of this alternative design?


This is still very much work in progress
Todo:
- [x] Handle recursion errors properly
- [x] Make stack trace and line numbers available
- [ ] Check if the raised exceptions are indeed the appropriate type
- [x] Update tests
- [x] Manual testing
- [ ] Remove code that is not being used anymore
- [ ] Update docs