### PR TITLE
allow users to evaluate an AST directly

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -317,7 +317,7 @@ class Interpreter(object):
         return self.eval(expr, **kw)
 
     def eval(self, expr, lineno=0, show_errors=True):
-        """Evaluate a single statement."""
+        """Evaluate a string."""
         self.lineno = lineno
         self.error = []
         self.start_time = time.time()
@@ -335,8 +335,17 @@ class Interpreter(object):
                 raise exc(errmsg)
             print(errmsg, file=self.err_writer)
             return
+        return self.eval_ast(node, self.lineno, expr, show_errors, self.start_time)
+    
+    def eval_ast(self, astexpr, lineno=0, expr=None, show_errors=True, start_time=None):
+        """Evaluate an AST."""
+        self.lineno = lineno
+        self.error = []
+        self.start_time = start_time
+        if self.start_time is None:
+            self.start_time = time.time()
         try:
-            return self.run(node, expr=expr, lineno=lineno)
+            return self.run(astexpr, expr=expr, lineno=lineno)
         except:
             errmsg = exc_info()[1]
             if len(self.error) > 0:

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -963,7 +963,10 @@ class TestEval(TestCase):
         assert(aeval2("abs(8)") == 8)
         assert(aeval2("abs(-8)") == 8)
         
-        
+    def test_manual_ast(self):
+        tree = ast.parse("2 + 3")
+        assert(type(tree) == ast.Module)
+        assert(self.interp.eval_ast(tree) == 5)
 
 
 


### PR DESCRIPTION
Sometimes the AST will come from a different source (for example when using [hy](http://docs.hylang.org/en/stable/) ).
Calling `run` directly misses some initialization and error handling.

This adds the `eval_ast` function which is like `eval`, but takes an AST instead of a string.