### PR TITLE
don't continue a try block after an error is caught

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -717,6 +717,7 @@ class Interpreter(object):
                         for tline in hnd.body:
                             self.run(tline)
                         break
+                break
         if no_errors and hasattr(node, 'orelse'):
             for tnode in node.orelse:
                 self.run(tnode)

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -618,6 +618,16 @@ class TestEval(TestCase):
             """))
         self.isvalue('x', -1)
 
+        self.interp(textwrap.dedent("""
+            x = 15
+            try:
+                raise Exception()
+                x = 20
+            except:
+                pass
+            """))
+        self.isvalue('x', 15)
+
     def test_tryelsefinally(self):
 
         self.interp(textwrap.dedent("""


### PR DESCRIPTION
In the current code, when catching an exception in a try block, the rest of the try block will still be executed.
For example:

    try:
        raise Exception("something wrong!")
        print("I'm fine")
    except:
        print("caught an error")

results in:

    caught an error
    I'm fine

This shouldn't happen. The "I'm fine" print should not be executed.
This is one of the problems mentioned in #52 

This PR fixes that and adds a test for this behaviour