### PR TITLE
Safe numpy

### DIFF
--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -9,6 +9,7 @@ import io
 import re
 import ast
 import math
+import numbers
 from sys import exc_info, version_info
 from tokenize import NAME as tk_NAME
 
@@ -182,8 +183,13 @@ LOCALFUNCS = {'open': _open, 'type': _type}
 
 def safe_pow(base, exp):
     """safe version of pow"""
-    if exp > MAX_EXPONENT:
-        raise RuntimeError("Invalid exponent, max exponent is {}".format(MAX_EXPONENT))
+    if isinstance(exp, numbers.Number):
+        if exp > MAX_EXPONENT:
+            raise RuntimeError("Invalid exponent, max exponent is {}".format(MAX_EXPONENT))
+    elif HAS_NUMPY:
+        if isinstance(exp, numpy.ndarray):
+            if numpy.max(exp) > MAX_EXPONENT:
+                raise RuntimeError("Invalid exponent, max exponent is {}".format(MAX_EXPONENT))
     return base ** exp
 
 
@@ -203,8 +209,13 @@ def safe_add(a, b):
 
 def safe_lshift(a, b):
     """safe version of lshift"""
-    if b > MAX_SHIFT:
-        raise RuntimeError("Invalid left shift, max left shift is {}".format(MAX_SHIFT))
+    if isinstance(b, numbers.Number):
+        if b > MAX_SHIFT:
+            raise RuntimeError("Invalid left shift, max left shift is {}".format(MAX_SHIFT))
+    elif HAS_NUMPY:
+        if isinstance(b, numpy.ndarray):
+            if numpy.max(b) > MAX_SHIFT:
+                raise RuntimeError("Invalid left shift, max left shift is {}".format(MAX_SHIFT))
     return a << b
 
 

--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -188,7 +188,7 @@ def safe_pow(base, exp):
             raise RuntimeError("Invalid exponent, max exponent is {}".format(MAX_EXPONENT))
     elif HAS_NUMPY:
         if isinstance(exp, numpy.ndarray):
-            if numpy.max(exp) > MAX_EXPONENT:
+            if numpy.nanmax(exp) > MAX_EXPONENT:
                 raise RuntimeError("Invalid exponent, max exponent is {}".format(MAX_EXPONENT))
     return base ** exp
 
@@ -214,7 +214,7 @@ def safe_lshift(a, b):
             raise RuntimeError("Invalid left shift, max left shift is {}".format(MAX_SHIFT))
     elif HAS_NUMPY:
         if isinstance(b, numpy.ndarray):
-            if numpy.max(b) > MAX_SHIFT:
+            if numpy.nanmax(b) > MAX_SHIFT:
                 raise RuntimeError("Invalid left shift, max left shift is {}".format(MAX_SHIFT))
     return a << b
 

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -820,9 +820,17 @@ class TestEval(TestCase):
         self.check_error(None)
         self.interp("10**10001")
         self.check_error('RuntimeError')
+        self.interp("10**array([10000, 10000, 10000])")
+        self.check_error(None)
+        self.interp("10**array([10000, 10000, 10001])")
+        self.check_error('RuntimeError')
         self.interp("1<<1000")
         self.check_error(None)
         self.interp("1<<1001")
+        self.check_error('RuntimeError')
+        self.interp("1<<array([1000, 1000, 1000])")
+        self.check_error(None)
+        self.interp("1<<array([1000, 1000, 1001])")
         self.check_error('RuntimeError')
 
     def test_safe_open(self):


### PR DESCRIPTION
The safe functions `safe_pow` and `safe_lshift` assumed that the exponent was a numerical value (int, float, etc.). The if statements (`if exp > MAX_EXPONENT:`) failed when a numpy array was passed for the exponent: 
`ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`

This change allows for numpy arrays to be passed as the exponent in these operations without the conditional statement failing. Instead of comparing the variable itself with `MAX_<>`, it compares the max value (using `numpy.nanmax`) with `MAX_<>`.