### PR TITLE
[Proposed] deprecate max run time now rather than later

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -62,8 +62,6 @@ ALL_NODES = ['arg', 'assert', 'assign', 'attribute', 'augassign', 'binop',
              'pass', 'print', 'raise', 'repr', 'return', 'slice', 'str',
              'subscript', 'try', 'tuple', 'unaryop', 'while']
 
-ERR_MAX_TIME = "Execution exceeded time limit, max runtime is {}s"
-
 class Interpreter(object):
     """create an asteval Interpreter: a restricted, simplified interpreter
     of mathematical expressions using Python syntax.
@@ -106,8 +104,6 @@ class Interpreter(object):
         whether to support `raise`.
     no_print : bool
         whether to support `print`.
-    max_time : float
-        deprecated, unreliable. max_time will be dropped soon. (default 86400)
     readonly_symbols : iterable or `None`
         symbols that the user can not assign to
     builtins_readonly : bool
@@ -117,7 +113,6 @@ class Interpreter(object):
     -----
     1. setting `minimal=True` is equivalent to setting all
        `no_***` options to `True`.
-    2. max_time is not reliable and no longer supported -- the keyword will be dropped soon.
     """
 
     def __init__(self, symtable=None, usersyms=None, writer=None,
@@ -125,7 +120,7 @@ class Interpreter(object):
                  no_if=False, no_for=False, no_while=False, no_try=False,
                  no_functiondef=False, no_ifexp=False, no_listcomp=False,
                  no_augassign=False, no_assert=False, no_delete=False,
-                 no_raise=False, no_print=False, max_time=86400,
+                 no_raise=False, no_print=False,
                  readonly_symbols=None, builtins_readonly=False):
 
         self.writer = writer or stdout
@@ -146,7 +141,6 @@ class Interpreter(object):
         self.retval = None
         self.lineno = 0
         self.start_time = time.time()
-        self.max_time = max_time
         self.use_numpy = HAS_NUMPY and use_numpy
 
         nodes = ALL_NODES[:]
@@ -280,8 +274,6 @@ class Interpreter(object):
         """Execute parsed Ast representation for an expression."""
         # Note: keep the 'node is None' test: internal code here may run
         #    run(None) and expect a None in return.
-        if time.time() - self.start_time > self.max_time:
-            raise RuntimeError(ERR_MAX_TIME.format(self.max_time))
         out = None
         if len(self.error) > 0:
             return out

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -841,14 +841,6 @@ class TestEval(TestCase):
         else:
             self.check_error('RuntimeError')
 
-    def test_runtime(self):
-        self.interp.max_time = 3
-        self.interp("""for x in range(2<<21): pass""")
-        self.check_error('RuntimeError', 'time limit')
-        self.interp("""while True: pass""")
-        self.check_error('RuntimeError', 'time limit')
-
-
     def test_kaboom(self):
         """ test Ned Batchelder's 'Eval really is dangerous' - Kaboom test (and related tests)"""
         self.interp("""(lambda fc=(lambda n: [c for c in ().__class__.__bases__[0].__subclasses__() if c.__name__ == n][0]):


### PR DESCRIPTION
In our local usage of asteval, we encountered intermittent bugs where asteval claimed functions were timing out after 86400 seconds. The python server executing these asteval interpreters had been up around 10 minutes, indicating something was very much awry.

As I was unable to reproduce manually, I'm unsure of the underlying cause. It's possible this is due to an unusual setup with time zones in our docker containers, as we've purged all the locale information. 

That said, removing the relevant code from our local fork of asteval was sufficient to stop this problem. I am proposing deprecating this feature now for the sake of others who may encounter this ill-defined bug.