### PR TITLE
Raise immediately on the first error

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -306,7 +306,10 @@ class Interpreter(object):
             return ret
         except:
             if with_raise:
-                self.raise_exception(node, expr=expr)
+                if len(self.error) == 0:
+                    # Unhandled exception that didn't go through raise_exception
+                    self.raise_exception(node, expr=expr)
+                raise
 
     def __call__(self, expr, **kw):
         """Call class instance as function."""


### PR DESCRIPTION
I has been using this package for a while now, but when I was initially scoping it out, I was running into Exception recursion errors similar to what @bek0s was running into on https://github.com/newville/asteval/issues/63 this morning. I had been running a fork for my application, but I thought it was a good time to propose bringing this patch into master.

The root of the issue is that `run` can be called on each node recursively, so if there's an exception, `raise_exception` can be called many times. My proposal here is to change the behavior of the `run` method so that it immediately raises when the first error occurs. I can't think of a case where you would want to catch multiple exceptions in the `error` list, nor can I see anything in the tests that indicate this is an intended feature. If this indeed an intended feature, we could add a `raise_immediately` flag to `eval` that defaults to `False` to maintain the existing functionality, but then uses this proposed functionality when set to `True`.

With this patch, I tested the sample code in https://github.com/newville/asteval/issues/63 and confirmed that it only produces one error as you'd expect.

What was the intention of the error list? Would it make sense to not maintain a list and always return the first exception immediately?