### PR TITLE
Don't raise AttributeError when using partials

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -782,10 +782,7 @@ class Interpreter(object):
         try:
             return func(*args, **keywords)
         except Exception as ex:
-            try:
-                func_name = func.__name__
-            except AttributeError:
-                func_name = str(func)
+            func_name = getattr(func, '__name__', str(func))
             self.raise_exception(
                 node, msg="Error running function call '%s' with args %s and "
                 "kwargs %s: %s" % (func_name, args, keywords, ex))

--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -782,9 +782,13 @@ class Interpreter(object):
         try:
             return func(*args, **keywords)
         except Exception as ex:
+            try:
+                func_name = func.__name__
+            except AttributeError:
+                func_name = str(func)
             self.raise_exception(
                 node, msg="Error running function call '%s' with args %s and "
-                "kwargs %s: %s" % (func.__name__, args, keywords, ex))
+                "kwargs %s: %s" % (func_name, args, keywords, ex))
 
     def on_arg(self, node):    # ('test', 'msg')
         """Arg for function definitions."""

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -3,12 +3,14 @@
 Base TestCase for asteval
 """
 import ast
+import math
 import os
 import textwrap
 import time
 import unittest
 import pytest
 
+from functools import partial
 from sys import version_info
 from tempfile import NamedTemporaryFile
 
@@ -1031,6 +1033,23 @@ class TestEval(TestCase):
         aeval("a_dict = {'a': 1, 'b': 2, 'c': 3, 'd': 4}")
         self.assertTrue(aeval("a_dict['a'] == 1"))
         self.assertTrue(aeval("a_dict['c'] == 3"))
+
+    def test_partial_exception(self):
+        sym_table = make_symbol_table(sqrt=partial(math.sqrt))
+
+        aeval = Interpreter(symtable=sym_table)
+
+        assert aeval("sqrt(4)") == 2
+
+        # Calling sqrt(-1) should raise a ValueError. When the interpreter
+        # encounters an exception, it attempts to form an error string that
+        # uses the function's __name__ attribute. Partials don't have a
+        # __name__ attribute, so we want to make sure that an AttributeError is
+        # not raised.
+    
+        result = aeval("sqrt(-1)")
+        assert aeval.error.pop().exc == ValueError
+
 
 class TestCase2(unittest.TestCase):
     def test_stringio(self):


### PR DESCRIPTION
I ran into an issue recently where I passed in a partial function into the symbol table, and then ran a method that raised an `Exception`. Instead of raising the `Exception` I expected, I instead encountered a `AttributeError` due to `functools.partial` objects not having a `__name__` attribute. This is best illustrated by example:

Before:
```python
In [1]: from functools import partial

In [2]: import math

In [3]: import asteval

In [4]: aeval=asteval.Interpreter()

In [5]: aeval.symtable["sqrt"] = partial(math.sqrt)

In [6]: aeval("sqrt(-1)")
AttributeError
   sqrt(-1)
'functools.partial' object has no attribute '__name__'
```

After:
```python
In [1]: from functools import partial

In [2]: import math

In [3]: import asteval

In [4]: aeval=asteval.Interpreter()

In [5]: aeval.symtable["sqrt"] = partial(math.sqrt)

In [6]: aeval("sqrt(-1)")
ValueError
   sqrt(-1)
Error running function call 'functools.partial(<built-in function sqrt>)' with args [-1] and kwargs {}: math domain error
```