### PR TITLE
Correct assertion message

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -403,7 +403,8 @@ class Interpreter(object):
     def on_assert(self, node):    # ('test', 'msg')
         """Assert statement."""
         if not self.run(node.test):
-            self.raise_exception(node, exc=AssertionError, msg=node.msg)
+            msg = node.msg.s if node.msg else ""
+            self.raise_exception(node, exc=AssertionError, msg=msg)
         return True
 
     def on_list(self, node):    # ('elt', 'ctx')

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -265,6 +265,8 @@ class TestEval(TestCase):
         self.check_error(None)
         self.interp('assert n==7')
         self.check_error('AssertionError')
+        self.interp('assert n==7, "no match"')
+        self.check_error('AssertionError', 'no match')
 
     def test_for(self):
         """for loops"""


### PR DESCRIPTION
Currently, if you raise an assertion error, you get a message like this:
```
In [1]: interpreter.eval("assert False, 'test'")

AssertionError: <_ast.Str object at 0x00FBEC90>
```

Ideally, you would get:
```
In [1]: interpreter.eval("assert False, 'test'")

AssertionError: test
```

This PR fixes that problem by pulling the string out of the `_ast.Str` object
