### PR TITLE
deny access to any __dunder__ attributes

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -489,17 +489,16 @@ class Interpreter:
             return delattr(sym, node.attr)
 
         # ctx is ast.Load
-        fmt = "cannot access attribute '%s' for %s"
-        if node.attr not in UNSAFE_ATTRS:
-            fmt = "no attribute '%s' for %s"
+        if not (node.attr in UNSAFE_ATTRS or
+                (node.attr.startswith('__') and
+                 node.attr.endswith('__'))):
             try:
                 return getattr(sym, node.attr)
             except AttributeError:
                 pass
 
         # AttributeError or accessed unsafe attribute
-        obj = self.run(node.value)
-        msg = fmt % (node.attr, obj)
+        msg = "no attribute '%s' for %s" % (node.attr, self.run(node.value))
         self.raise_exception(node, exc=AttributeError, msg=msg)
 
     def on_assign(self, node):    # ('targets', 'value')

--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -40,12 +40,13 @@ RESERVED_WORDS = ('and', 'as', 'assert', 'break', 'class', 'continue',
 NAME_MATCH = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$").match
 
 UNSAFE_ATTRS = ('__subclasses__', '__bases__', '__globals__', '__code__',
+                '__reduce__', '__reduce_ex__',  '__mro__',
                 '__closure__', '__func__', '__self__', '__module__',
                 '__dict__', '__class__', '__call__', '__get__',
                 '__getattribute__', '__subclasshook__', '__new__',
                 '__init__', 'func_globals', 'func_code', 'func_closure',
                 'im_class', 'im_func', 'im_self', 'gi_code', 'gi_frame',
-                '__asteval__', 'f_locals', '__mro__')
+                'f_locals', '__asteval__')
 
 # inherit these from python's __builtins__
 FROM_PY = ('ArithmeticError', 'AssertionError', 'AttributeError',


### PR DESCRIPTION
See #86 for motivation and discussion.   This removes access to all `__dunder__` attributes.