### PR TITLE
Performance of Interpreter construction

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -184,8 +184,8 @@ class Interpreter:
 
         self.no_deepcopy = [key for key, val in symtable.items()
                             if (callable(val)
-                                or 'numpy.lib.index_tricks' in repr(val)
-                                or inspect.ismodule(val))]
+                                or inspect.ismodule(val)
+                                or 'numpy.lib.index_tricks' in repr(val))]
 
     def remove_nodehandler(self, node):
         """remove support for a node

--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -395,9 +395,10 @@ def make_symbol_table(use_numpy=True, **kws):
         deprecated = ['str', 'bool', 'int', 'float', 'complex', 'pv', 'rate',
                       'pmt', 'ppmt', 'npv', 'nper', 'long', 'mirr', 'fv',
                       'irr', 'ipmt']
+        numpy_check = int(numpy_version[0]) == 1 and int(numpy_version[1]) >= 20
+
         for sym in FROM_NUMPY:
-            if (int(numpy_version[0]) == 1 and int(numpy_version[1]) >= 20 and
-                    sym in deprecated):
+            if (numpy_check and sym in deprecated):
                 continue
             if hasattr(numpy, sym):
                 symtable[sym] = getattr(numpy, sym)


### PR DESCRIPTION
The `Interpreter` is constructed many times when fitting with `lmfit`. This PR improves performance by

* Taking the calculation of the number version out of the loop
* Changing the order of the check for `no_deepcopy`

Current master branch:
```
%timeit Interpreter()
364 µs ± 21.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
``` 
With this PR
``` 
%timeit Interpreter()
271 µs ± 23.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
``` 

@newville 