### PR TITLE
Remove redundant wheel dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+requires = ["setuptools>=45", "setuptools_scm>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
The dependency on `wheel` is redundant since setuptools' build backend
adds it automatically.  Listing it in documentation has been a mistake
and it has been fixed since.  See:
https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a