### PR TITLE
🩹 Fix missing numpy rename values returned by make_symbol_table

### DIFF
--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -180,7 +180,7 @@ if HAS_NUMPY:
         FROM_NUMPY = tuple(set(FROM_NUMPY) - set(numpy_deprecated))
 
     FROM_NUMPY = tuple(sym for sym in FROM_NUMPY if hasattr(numpy, sym))
-    NUMPY_RENAMES = {sym: value for sym, value in NUMPY_RENAMES.items() if hasattr(numpy, sym)}
+    NUMPY_RENAMES = {sym: value for sym, value in NUMPY_RENAMES.items() if hasattr(numpy, value)}
 
     NUMPY_TABLE = {}
     for sym in FROM_NUMPY:

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -989,6 +989,14 @@ class TestEval(TestCase):
             assert_allclose(x1, 0.50, rtol=0.001)
             assert_allclose(x2, 0.866025, rtol=0.001)
             assert_allclose(x3, 1.00, rtol=0.001)
+            
+    
+    def test_numpy_renames_in_custom_symtable(self):
+        """test that numpy renamed functions are in symtable"""
+        if HAS_NUMPY:
+            sym_table = make_symbol_table()
+            
+            assert "ln" in sym_table
 
     def test_readonly_symbols(self):
 


### PR DESCRIPTION
Hi there, I just installed the latest release (`0.9.28`) and found that the `NUMPY_RENAMES` values were missing in the symbol list created with `make_symbol_table` which caused a crash when creating an `Interpreter` with `Interpreter(symtable=make_symbol_table(...))` and using renamed functions like `ln`.

Turned out to be a little from-to-mixup when checking that the symbol exists in `numpy` since the value and not the key should exists in numpy 
https://github.com/newville/asteval/blob/4af02f779ea4309f94d763560f522d2f8a794c32/asteval/astutils.py#L183

I also added a unitest for the case so a regression can't sneak in easily in the future.