### PR TITLE
Fix numpy 1.24 deprecation warnings

### DIFF
--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -177,6 +177,9 @@ if HAS_NUMPY:
         numpy_deprecated = ['str', 'bool', 'int', 'float', 'complex', 'pv', 'rate',
                             'pmt', 'ppmt', 'npv', 'nper', 'long', 'mirr', 'fv',
                             'irr', 'ipmt']
+        # aliases deprecated in NumPy v1.24.0
+        numpy_deprecated += ['int0', 'uint0', 'bool8']
+
         FROM_NUMPY = tuple(set(FROM_NUMPY) - set(numpy_deprecated))
 
     FROM_NUMPY = tuple(sym for sym in FROM_NUMPY if hasattr(numpy, sym))


### PR DESCRIPTION
In numpy 1.24 a couple of aliases have been deprecated. In this PR we add the deprecated aliases to the list so they are not added to the asteval symbol table (and they do not generate warnings when asteval is used with numpy 1.24).

If these aliases are still in use and we do not want to remove them, we could create a PR what suppresses the warnings during addition for these elements. 

@newville 