### PR TITLE
Add deprecations for numpy 2.0

### DIFF
--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -182,6 +182,10 @@ if HAS_NUMPY:
         # aliases deprecated in NumPy v1.24.0
         numpy_deprecated += ['int0', 'uint0', 'bool8']
 
+    if int(numpy_version[0]) >= 2 :
+        # aliases deprecated in NumPy v2.0
+        numpy_deprecated += ['bool', 'chararray', 'long', 'str']
+
     FROM_NUMPY = tuple(set(FROM_NUMPY) - set(numpy_deprecated))
 
     FROM_NUMPY = tuple(sym for sym in FROM_NUMPY if hasattr(numpy, sym))


### PR DESCRIPTION
In this PR we add four attributes that have been deprecated in numpy 2.0. Three out of the four have already been deprecated before, but are not selected because the statement `if int(numpy_version[0]) == 1 and int(numpy_version[1]) >= 20` is false for numpy 2.0.

Numpy 2.0 is scheduled to be released end of 2023, see https://github.com/numpy/numpy/issues/24300
