### PR TITLE
guard attribute assignment with safe_setattr

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -46,8 +46,8 @@ from sys import exc_info, stderr, stdout
 
 from .astutils import (HAS_NUMPY, ExceptionHolder, ReturnedNone,
                        Empty, make_symbol_table, op2func,
-                       safe_getattr, safe_format, valid_symbol_name,
-                       Procedure)
+                       safe_getattr, safe_setattr, safe_format,
+                       valid_symbol_name, Procedure)
 
 ALL_NODES = ['arg', 'assert', 'assign', 'attribute', 'augassign',
              'binop', 'boolop', 'break', 'call', 'compare',
@@ -575,7 +575,8 @@ class Interpreter:
                 msg = f"cannot assign to attribute {node.attr}"
                 self.raise_exception(node, exc=AttributeError, msg=msg)
 
-            setattr(self.run(node.value), node.attr, val)
+            safe_setattr(self.run(node.value), node.attr, val,
+                         self.raise_exception, node)
 
         elif node.__class__ == ast.Subscript:
             self.run(node.value)[self.run(node.slice)] = val

--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -301,6 +301,15 @@ def safe_getattr(obj, attr, raise_exc, node, allow_unsafe_modules=False):
     else:
         return getattr(obj, attr, None)
 
+
+def safe_setattr(obj, attr, val, raise_exc, node):
+    """safe version of setattr"""
+    if attr in UNSAFE_ATTRS or (attr.startswith('__') and attr.endswith('__')):
+        msg = f"no safe attribute '{attr}' for {repr(obj)}"
+        raise_exc(node, exc=AttributeError, msg=msg)
+    else:
+        setattr(obj, attr, val)
+
 class SafeFormatter(Formatter):
     def __init__(self, raise_exc, node):
         self.raise_exc = raise_exc

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -1657,6 +1657,23 @@ def test_unsafe_procedure_access(nested):
     assert etype == 'AttributeError'
 
 @pytest.mark.parametrize("nested", [False, True])
+def test_unsafe_attribute_assignment(nested):
+    """attribute assignment must honor the same guard as attribute reads:
+    writing a dunder/unsafe attribute was not checked, so `open.__defaults__`
+    could be overwritten even though reading it is blocked. `open` is a shared
+    module-level function, so the mutation also leaked across interpreters.
+    """
+    interp = make_interpreter(nested_symtable=nested)
+    interp(textwrap.dedent("""
+            open.__defaults__ = ('rb', 0, None)
+     """),  raise_errors=False)
+
+    error = interp.error[0]
+    etype, fullmsg = error.get_error()
+    assert 'no safe attribute' in error.msg
+    assert etype == 'AttributeError'
+
+@pytest.mark.parametrize("nested", [False, True])
 def test_unsafe_format_string_access(nested):
     """
     addressing https://github.com/lmfit/asteval/security/advisories/GHSA-3wwr-3g9f-9gc7


### PR DESCRIPTION
Attribute reads run through `safe_getattr`, but attribute writes did not:

    >>> a = Interpreter()
    >>> a("open.__globals__")                      # read: blocked
    AttributeError: no safe attribute '__globals__' for <function _open ...>
    >>> a("open.__defaults__ = ('rb', 0, None)")   # write: allowed
    >>> Interpreter().symtable["open"].__defaults__
    ('rb', 0, None)

`node_assign` calls `setattr` directly, so any dunder / `UNSAFE_ATTRS` name the read path rejects can still be written. `open` and `type` are shared module-level functions, so the write also persists into freshly created interpreters.

Add `safe_setattr` applying the same name check as `safe_getattr`, and route the attribute-store branch through it. Non-dunder writes (`g.x = 1`, `arr.shape = ...`) are unaffected.