### PR TITLE
cap int * str in safe_mult to match str * int

### DIFF
--- a/asteval/astutils.py
+++ b/asteval/astutils.py
@@ -226,6 +226,8 @@ def safe_pow(base, exp):
 
 def safe_mult(arg1, arg2):
     """safe version of multiply"""
+    if isinstance(arg1, int) and isinstance(arg2, str):
+        arg1, arg2 = arg2, arg1
     if isinstance(arg1, str) and isinstance(arg2, int) and len(arg1) * arg2 > MAX_STR_LEN:
         raise RuntimeError(f"String length exceeded, max string length is {MAX_STR_LEN}")
     return arg1 * arg2

--- a/tests/test_asteval.py
+++ b/tests/test_asteval.py
@@ -1224,6 +1224,8 @@ def test_safe_funcs(nested):
     check_error(interp, 'RuntimeError')
     interp("'*'*(2<<17) + '*'")
     check_error(interp, 'RuntimeError')
+    interp("(1+2<<17)*'*'")
+    check_error(interp, 'RuntimeError')
     interp("1.01**10000")
     check_error(interp, None)
     interp("1.01**10001")


### PR DESCRIPTION
safe_mult only caps the string when it is the left operand:

    >>> Interpreter()("'*'*(1+2<<17)", raise_errors=True)   # str * int
    RuntimeError: String length exceeded, max string length is 262144
    >>> Interpreter()("(1+2<<17)*'*'", raise_errors=True)   # int * str
    # builds a 262145-char string, no error

The check is `isinstance(arg1, str) and isinstance(arg2, int)`, so writing the
multiply as `int * str` slips past the MAX_STR_LEN cap that ast.Mult routes
through. Normalize operand order before the length check so both forms are
capped. Added the int*str case next to the existing str*int test in
test_safe_funcs.
